### PR TITLE
Removes define of CLEF_DEBUG from plugin.

### DIFF
--- a/wpclef.php
+++ b/wpclef.php
@@ -27,7 +27,6 @@ if ( ! defined('ABSPATH') ) exit();
 // Useful global constants
 define( 'CLEF_VERSION', '1.9' );
 define( 'CLEF_PATH',    WP_PLUGIN_DIR . '/wpclef/' );
-define( 'CLEF_DEBUG', false);
 if (CLEF_DEBUG) {
     require_once('includes/lib/symlink-fix.php');
 }


### PR DESCRIPTION
This is really a define that should be in wp-config.php for the specific site. I recommend removing it from the core plugin. That way someone can enable it and not have to worry about modifying core plugin files.

Other benefit - you can keep it enabled across the dev cycle, and updates.
