### PR TITLE
Small fix to how CLEF_PATH is defined.

### DIFF
--- a/wpclef.php
+++ b/wpclef.php
@@ -26,7 +26,7 @@ if ( ! defined('ABSPATH') ) exit();
 
 // Useful global constants
 define( 'CLEF_VERSION', '1.9' );
-define( 'CLEF_PATH',    WP_PLUGIN_DIR . '/wpclef/' );
+define( 'CLEF_PATH',    plugin_dir_path( __FILE__ ) );
 define( 'CLEF_DEBUG', false);
 if (CLEF_DEBUG) {
     require_once('includes/lib/symlink-fix.php');


### PR DESCRIPTION
Changed it from hardcoded sub-folder name to use `plugin_dir_path()`

This is a small change, but it solves some PHP errors you get if you install clef with a different folder name.
