### PR TITLE
Move all code that touches the user out of `plugins_loaded`

### DIFF
--- a/includes/class.clef-admin.php
+++ b/includes/class.clef-admin.php
@@ -42,6 +42,9 @@ class ClefAdmin {
         add_action('admin_init', array($this, "settings_form"));
         add_action('admin_init', array($this, "multisite_settings_edit"));
 
+        // Display the badge message, if appropriate
+        add_action('admin_init', array($this, 'clef_hook_onboarding'));
+
         add_action('clef_hook_admin_menu', array($this, "hook_admin_menu"));
         add_filter('clef_add_affiliate', array($this, "add_affiliates"));
 
@@ -61,7 +64,9 @@ class ClefAdmin {
             array('capability' => 'read')
         );
 
-        // Display the badge message, if appropriate
+    }
+
+    public function clef_hook_onboarding() {
         do_action('clef_hook_onboarding');
     }
 

--- a/includes/class.clef-logout.php
+++ b/includes/class.clef-logout.php
@@ -8,21 +8,20 @@ class ClefLogout {
     private function __construct($settings) {
         $this->settings = $settings;
         $this->initialize_hooks();
-
-        if (!defined('DOING_AJAX') || !DOING_AJAX) {
-            $this->logged_out_check(array("redirect" => true));
-        }
     }
 
     public function initialize_hooks() {
         add_filter( 'heartbeat_received',  array($this, "hook_heartbeat"), 10, 3);
-        $this->register_logout_hook_handler();
+        add_filter( 'init', array($this, 'logout_hook_handler'));
+        if (!defined('DOING_AJAX') || !DOING_AJAX) {
+            add_filter('init', array($this, "logged_out_check_with_redirect"));
+        }
     }
 
     /**
      * Handle a Clef logout hook handshake, if the parameters exist.
      */
-    public function register_logout_hook_handler() {
+    public function logout_hook_handler() {
         if(isset($_POST) && isset($_POST['logout_token'])) {
 
             $args = array(
@@ -60,6 +59,10 @@ class ClefLogout {
             // upon success, log user out
             update_user_meta($user->ID, 'logged_out_at', time());
         }
+    }
+
+    public function logged_out_check_with_redirect() {
+        $this->logged_out_check(array("redirect" => true));
     }
 
     public function logged_out_check($opts = array("redirect" => false)) {

--- a/includes/class.clef-user-settings.php
+++ b/includes/class.clef-user-settings.php
@@ -10,8 +10,6 @@ class ClefUserSettings {
     protected function __construct($settings) {
         $this->settings = $settings;
         $this->initialize_hooks();
-
-        add_action('wp_enqueue_scripts', array($this, 'register_assets'));
     }
 
     public function initialize_hooks() {
@@ -19,6 +17,7 @@ class ClefUserSettings {
         add_action('wp_footer', array($this, 'print_assets'));
 
         add_shortcode('clef_user_settings', array($this, 'render'));
+        add_action('wp_enqueue_scripts', array($this, 'register_assets'));
 
         global $clef_ajax;
         $clef_ajax->add_action(


### PR DESCRIPTION
Messing with the user in before `init` causes issues with plugins like BuddyPress, so we move all user touching code to the init hook.
