### PR TITLE
Fixes issue where bad nonce is being reported on settings save

### DIFF
--- a/includes/lib/ajax-settings/ajax-settings.php
+++ b/includes/lib/ajax-settings/ajax-settings.php
@@ -52,7 +52,7 @@ class AjaxSettings {
         }
 
         // strip off any leading characters before json starts and then parse
-        $stripped = preg_replace('/^.*{/', '{', $HTTP_RAW_POST_DATA);
+        $stripped = preg_replace('/^.*?{/', '{', $HTTP_RAW_POST_DATA);
         $settings = json_decode($stripped, true);
 
         if (!$settings) wp_die(__('Settings could not be parsed — this may be caused by a plugin conflict.'));


### PR DESCRIPTION
Issue was caused by plugins prepending text to the beginning of our payload. To fix, we strip everything before JSON starts.
