### PR TITLE
Fixes PHP error if a registration error occurs

### DIFF
--- a/includes/class.clef-login.php
+++ b/includes/class.clef-login.php
@@ -305,7 +305,7 @@ class ClefLogin {
                     if(is_wp_error($id)) {
                         return new WP_Error(
                             'clef',
-                            __("An error occurred when creating your new account: ", 'clef') . $res->get_error_message()
+                            __("An error occurred when creating your new account: ", 'clef') . $id->get_error_message()
                         );
                     }
                     $user = get_user_by('id', $id );


### PR DESCRIPTION
We have the correct code, but a typo causes a PHP error for a null variable if an error occurs when a user tries to sign up for a site with Clef.
