### PR TITLE
Fixes a PHP error in the Clef logout hook handling

### DIFF
--- a/includes/class.clef-logout.php
+++ b/includes/class.clef-logout.php
@@ -33,19 +33,27 @@ class ClefLogout {
             $response = wp_remote_post( CLEF_API_BASE . 'logout', array( 'method' => 'POST',
                 'timeout' => 45, 'body' => $args ) );
 
-            $body = json_decode( $response['body'] );
-
-            if (isset($body->success) && isset($body->clef_id)) {
-                $this->set_user_logged_out_at($body->clef_id);
+            if (is_wp_error($response)) {
                 $return = array(
-                    "success" => true
+                    "error" => $response->get_error_message(),
+                    "success" => false
                 );
             } else {
-                $return = array(
-                    "success" => false,
-                    "error" => $body->error
-                );
+                $body = json_decode( $response['body'] );
+
+                if (isset($body->success) && isset($body->clef_id)) {
+                    $this->set_user_logged_out_at($body->clef_id);
+                    $return = array(
+                        "success" => true
+                    );
+                } else {
+                    $return = array(
+                        "success" => false,
+                        "error" => $body->error
+                    );
+                }
             }
+
             echo(json_encode($return));
             exit();
         }


### PR DESCRIPTION
If the logout hook handler fails to reach the Clef servers with the URL request, it will return a WP_Error. Previously, we didn't handle the error and that caused a PHP server error. With this commit, we handle it correctly.
