### PR TITLE
Removes clef-centric registration option

### DIFF
--- a/includes/class.clef-admin.php
+++ b/includes/class.clef-admin.php
@@ -375,7 +375,6 @@ class ClefAdmin {
         $settings = $form->addSection('clef_settings', __('API Settings', 'clef'));
         $settings->addField('app_id', __('Application ID', "clef"), Settings_API_Util_Field::TYPE_TEXTFIELD);
         $settings->addField('app_secret', __('Application Secret', "clef"), Settings_API_Util_Field::TYPE_TEXTFIELD);
-        $settings->addField('register', __('Register with Clef', 'clef'), Settings_API_Util_Field::TYPE_CHECKBOX);
 
         $pw_settings = $form->addSection('clef_password_settings', __('Password Settings', 'clef'), '');
         $pw_settings->addField('disable_passwords', __('Disable passwords for Clef users', "clef"), Settings_API_Util_Field::TYPE_CHECKBOX);

--- a/includes/class.clef-internal-settings.php
+++ b/includes/class.clef-internal-settings.php
@@ -167,10 +167,6 @@ class ClefInternalSettings {
         return !!get_site_option(self::MS_ALLOW_OVERRIDE_OPTION);
     }
 
-    public function registration_with_clef_is_allowed() {
-        return !!$this->get('clef_settings_register');
-    }
-
     public function should_embed_clef_login() {
         return $this->get('clef_form_settings_embed_clef');
     }

--- a/includes/class.clef-login.php
+++ b/includes/class.clef-login.php
@@ -136,7 +136,7 @@ class ClefLogin {
     }
 
     public function register_form() {
-        if ($this->settings->is_configured() && $this->settings->registration_with_clef_is_allowed()) {
+        if ($this->settings->is_configured()) {
             echo ClefUtils::render_template('register.tpl', array(
                 "redirect_url" => $this->get_callback_url(),
                 "app_id" => $this->settings->get( 'clef_settings_app_id' )
@@ -305,23 +305,25 @@ class ClefLogin {
                 $user = get_user_by('email', $email);
 
                 if (!$user) {
-                    if(!$this->settings->registration_with_clef_is_allowed()) {
+                    if (get_option('users_can_register')) {
+                        // Users can register, so create a new user
+                        $id = wp_create_user($email, wp_generate_password(16, FALSE), $email);
+                        if(is_wp_error($id)) {
+                            return new WP_Error(
+                                'clef',
+                                __("An error occurred when creating your new account: ", 'clef') . $id->get_error_message()
+                            );
+                        }
+                        $user = get_user_by('id', $id );
+                    } else {
+                        // Users cannot register so set things up to automatically
+                        // connect the user account if they log in with username & password
                         $this->clef_id_to_connect = $clef_id;
                         return new WP_Error(
                             'clef',
                             __("There's <b>no WordPress user</b> connected to your Clef account. <br></br> Log in with your standard username and password to <b>automatically connect your Clef account</b> now.", 'clef')
                         );
                     }
-
-                    // Users can register, so create a new user
-                    $id = wp_create_user($email, wp_generate_password(16, FALSE), $email);
-                    if(is_wp_error($id)) {
-                        return new WP_Error(
-                            'clef',
-                            __("An error occurred when creating your new account: ", 'clef') . $id->get_error_message()
-                        );
-                    }
-                    $user = get_user_by('id', $id );
                 }
 
                 ClefUtils::associate_clef_id($clef_id, $user->ID);

--- a/templates/admin/form.tpl.php
+++ b/templates/admin/form.tpl.php
@@ -120,10 +120,6 @@
                     <label for=""><?php _e("Application Secret", "clef"); ?></label>
                     <?php $form->getSection('clef_settings')->getField('app_secret')->render(); ?>
                 </div>
-                <div class="input-container">
-                    <label for=""><?php _e("Allow visitors to your site to register with Clef", "clef"); ?></label>
-                    <?php $form->getSection('clef_settings')->getField('register')->render(); ?>
-                </div>
             </div>
         </div>
         <?php submit_button(); ?>


### PR DESCRIPTION
This PR removes the ability to dictate whether registration with Clef is explicitly allowed or disallowed. Instead, we rely on the website's setting for whether users can register.

/cc @lolux 
