### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/clef/wordpress.png?label=ready&title=Ready)](https://waffle.io/clef/wordpress)
 # [Clef for WordPress](http://wordpress.org/plugins/wpclef/) [![Build Status](https://travis-ci.org/clef/wordpress.svg?branch=master)](https://travis-ci.org/clef/wordpress)
 
 Welcome to the Clef for WordPress development repository!


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/clef/wordpress

This was requested by a real person (user lolux) on waffle.io, we're not trying to spam you.
