### PR TITLE
Add css exception for 'rp' wp-login.php action

### DIFF
--- a/assets/src/sass/main.scss
+++ b/assets/src/sass/main.scss
@@ -13,7 +13,7 @@
     }
 }
 
-.clef-login-form:not(.login-action-register):not(.login-action-lostpassword) {
+.clef-login-form:not(.login-action-register):not(.login-action-lostpassword):not(.login-action-rp) {
     .clef-login-container {
         .clef-button-container {
             margin-bottom: 30px;


### PR DESCRIPTION
Makes wpclef compatible with the strong pwd change introduced in 4.3: https://make.wordpress.org/core/2015/07/28/passwords-strong-by-default/