### PR TITLE
Change logout hook url setting from home_url to wp_login_url

### DIFF
--- a/includes/class.clef-admin.php
+++ b/includes/class.clef-admin.php
@@ -270,7 +270,7 @@ class ClefAdmin {
             'setup' => array(
                 'siteName' => get_option('blogname'),
                 'siteDomain' => get_option('siteurl'),
-                'logoutHook' => home_url('/'),
+                'logoutHook' => wp_login_url(),
                 'source' => 'wordpress',
                 'affiliates' => apply_filters('clef_add_affiliate', array())
             ),


### PR DESCRIPTION
Closes https://github.com/clef/clef-wordpress/issues/161

This proposed change solves two use cases that currently experience logout hook failure upon installation.

1. **Maintenance mode**: maintenance mode plugins redirect all WP http requests except for requests to the login script. When the Clef logout hook is set to `home_url`, the logout hook ping is defeated/redirected by the maintenance mode plugin. If it is set to `wp_login_url`, the ping reaches this non-pre-processed endpoint.

2. **Static page network-layer caching**: if a user's WP site employs extensive network-layer caching to achieve cached static pages (e.g., "cache everything mode" in CloudFlare), and if the logout hook url is set to `home_url`, then the network caching layer prevents the Clef logout hook from reaching the application. Since users in this scenario are forced of necessity to apply a network caching exception to the login script, the Clef logout hook can make use of this non-cached endpoint.