### PR TITLE
Update state cookie name for Pantheon compatibility

### DIFF
--- a/includes/class.clef-utils.php
+++ b/includes/class.clef-utils.php
@@ -7,6 +7,13 @@
  */
 class ClefUtils {
     public static $default_roles = array("Subscriber", "Contributor", "Author", "Editor", "Administrator", "Super Administrator" );
+
+    /*
+    * The cookie for the state parameter used in the Clef OAuth handshake. 
+    * To prevent deletion by some caches (like Pantheon), it is prefixed with SESS.
+    */
+    public static $cookie_name = "SESSclefstate";
+
     /**
      * Runs esc_html on strings. Leaves input untouched if it's not a string.
      *
@@ -241,18 +248,18 @@ class ClefUtils {
     }
 
     public static function initialize_state($override = false) {
-        if (!$override && isset($_COOKIE['_clef_state']) && $_COOKIE['_clef_state']) return;
+        if (!$override && isset($_COOKIE[self::$cookie_name]) && $_COOKIE[self::$cookie_name]) return;
 
         $state = wp_generate_password(24, false);
-        @setcookie('_clef_state', $state, (time() + 60 * 60 * 24), '/', '', is_ssl(), true);
-        $_COOKIE['_clef_state'] = $state;
+        @setcookie(self::$cookie_name, $state, (time() + 60 * 60 * 24), '/', '', is_ssl(), true);
+        $_COOKIE[self::$cookie_name] = $state;
 
         return $state;
     }
 
     public static function get_state() {
-        if (!isset($_COOKIE['_clef_state']) || !$_COOKIE['_clef_state']) ClefUtils::initialize_state();
-        return $_COOKIE['_clef_state'];
+        if (!isset($_COOKIE[self::$cookie_name]) || !$_COOKIE[self::$cookie_name]) ClefUtils::initialize_state();
+        return $_COOKIE[self::$cookie_name];
     }
 
     public static function verify_state() {


### PR DESCRIPTION
This commit changes the name of the cookie used to store the OAuth state
parameter from `_clef_state` to `SESSclefstate`. We do this to avoid deletion
by certain caches (like Varnish on Pantheon).

PLUG-9 #finish