### PR TITLE
Switch to default WP cookie naming convention for session and state cookies

### DIFF
--- a/includes/class.clef-core.php
+++ b/includes/class.clef-core.php
@@ -86,6 +86,11 @@ class ClefCore {
         $settings_changes = false;
 
         if ($previous_version) {
+            if (version_compare($previous_version, '2.5.0', '<')) {
+                if (isset($_COOKIE['clef_wp_session'])) {
+                    ClefSession::migrate('clef_wp_session');
+                }
+            }
 
             if (version_compare($previous_version, '2.2.9.1', '<')) {
                 $this->onboarding->set_first_login_true();

--- a/includes/class.clef-session.php
+++ b/includes/class.clef-session.php
@@ -56,7 +56,7 @@ class ClefSession {
 
             // Use WP_Session (default)
             if ( ! defined( 'WP_SESSION_COOKIE' ) )
-                define( 'WP_SESSION_COOKIE', 'clef_wp_session' );
+                define( 'WP_SESSION_COOKIE', 'wordpress_clef_session' );
 
             if ( ! class_exists( 'Recursive_ArrayAccess' ) )
                 require_once CLEF_PATH . 'includes/lib/wp-session/class-recursive-arrayaccess.php';

--- a/includes/class.clef-session.php
+++ b/includes/class.clef-session.php
@@ -12,6 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 class ClefSession {
 
     private static $instance = null;
+    private static $cookie_name = 'wordpress_clef_session';
 
     /**
      * Holds our session data
@@ -43,7 +44,7 @@ class ClefSession {
      *
      * @since 1.5
      */
-    public function __construct() {
+    public function __construct($cookie_name = false) {
 
         $this->use_php_sessions = defined( 'CLEF_USE_PHP_SESSIONS' ) && CLEF_USE_PHP_SESSIONS;
 
@@ -56,7 +57,7 @@ class ClefSession {
 
             // Use WP_Session (default)
             if ( ! defined( 'WP_SESSION_COOKIE' ) )
-                define( 'WP_SESSION_COOKIE', 'wordpress_clef_session' );
+                define( 'WP_SESSION_COOKIE', self::$cookie_name );
 
             if ( ! class_exists( 'Recursive_ArrayAccess' ) )
                 require_once CLEF_PATH . 'includes/lib/wp-session/class-recursive-arrayaccess.php';
@@ -69,7 +70,7 @@ class ClefSession {
             add_filter( 'wp_session_expiration', array( $this, 'set_expiration_time' ), 99999 );
         }
 
-        $this->init();
+        $this->init($cookie_name);
     }
 
 
@@ -80,11 +81,11 @@ class ClefSession {
      * @since 1.5
      * @return void
      */
-    public function init() {
+    public function init($cookie_name) {
         if( $this->use_php_sessions )
             $this->session = isset( $_SESSION['clef'] ) && is_array( $_SESSION['clef'] ) ? $_SESSION['clef'] : array();
         else
-            $this->session = WP_Session::get_instance();
+            $this->session = WP_Session::get_instance($cookie_name);
 
         return $this->session;
     }
@@ -148,6 +149,23 @@ class ClefSession {
      */
     public function set_expiration_time( $exp ) {
         return current_time( 'timestamp' ) + ( 60 * 60 * 24 * 365 );
+    }
+
+    public static function migrate($old_cookie_name) {
+        if ( ! class_exists( 'Recursive_ArrayAccess' ) )
+            require_once CLEF_PATH . 'includes/lib/wp-session/class-recursive-arrayaccess.php';
+
+        if ( ! class_exists( 'WP_Session' ) ) {
+            require_once CLEF_PATH . 'includes/lib/wp-session/class-wp-session.php';
+            require_once CLEF_PATH . 'includes/lib/wp-session/wp-session.php';
+        }
+
+        $old_session = new WP_Session($old_cookie_name);
+        $new_session = ClefSession::start();
+
+        foreach ($old_session as $key => $value) {
+            $new_session->set($key, $value);
+        }
     }
 
     public static function start() {

--- a/includes/class.clef-utils.php
+++ b/includes/class.clef-utils.php
@@ -10,9 +10,8 @@ class ClefUtils {
 
     /*
     * The cookie for the state parameter used in the Clef OAuth handshake. 
-    * To prevent deletion by some caches (like Pantheon), it is prefixed with SESS.
     */
-    public static $cookie_name = "SESSclefstate";
+    public static $cookie_name = "wordpress_clef_state";
 
     /**
      * Runs esc_html on strings. Leaves input untouched if it's not a string.

--- a/includes/lib/wp-session/class-wp-session.php
+++ b/includes/lib/wp-session/class-wp-session.php
@@ -52,9 +52,9 @@ final class WP_Session extends Recursive_ArrayAccess implements Iterator, Counta
      *
      * @return bool|WP_Session
      */
-    public static function get_instance() {
+    public static function get_instance($cookie_name = false) {
         if ( ! self::$instance ) {
-            self::$instance = new self();
+            self::$instance = new self($cookie_name);
         }
 
         return self::$instance;
@@ -68,9 +68,15 @@ final class WP_Session extends Recursive_ArrayAccess implements Iterator, Counta
      * @param $session_id
      * @uses apply_filters Calls `wp_session_expiration` to determine how long until sessions expire.
      */
-    protected function __construct() {
-        if ( isset( $_COOKIE[WP_SESSION_COOKIE] ) ) {
-            $cookie = stripslashes( $_COOKIE[WP_SESSION_COOKIE] );
+    public function __construct($cookie_name = false) {
+        if ($cookie_name) {
+            $this->cookie_name = $cookie_name;
+        } else {
+            $this->cookie_name = WP_SESSION_COOKIE;
+        }
+
+        if ( isset( $_COOKIE[$this->cookie_name] ) ) {
+            $cookie = stripslashes( $_COOKIE[$this->cookie_name] );
             $cookie_crumbs = explode( '||', $cookie );
 
             $this->session_id = $cookie_crumbs[0];
@@ -121,7 +127,7 @@ final class WP_Session extends Recursive_ArrayAccess implements Iterator, Counta
      * Set the session cookie
      */
     protected function set_cookie() {
-        setcookie( WP_SESSION_COOKIE, $this->session_id . '||' . $this->expires . '||' . $this->exp_variant , $this->expires, COOKIEPATH, COOKIE_DOMAIN );
+        setcookie( $this->cookie_name, $this->session_id . '||' . $this->expires . '||' . $this->exp_variant , $this->expires, COOKIEPATH, COOKIE_DOMAIN );
     }
 
     /**


### PR DESCRIPTION
Fixes Pantheon.io and all other Varnish cache bypasses that employ the default `wordpress_` prefix cookie naming convention in their VCLs