### PR TITLE
fix(session): namespace WP_Session to \Clef\WP_Session

### DIFF
--- a/includes/class.clef-session.php
+++ b/includes/class.clef-session.php
@@ -56,18 +56,18 @@ class ClefSession {
         } else {
 
             // Use WP_Session (default)
-            if ( ! defined( 'WP_SESSION_COOKIE' ) )
-                define( 'WP_SESSION_COOKIE', self::$cookie_name );
+            if ( ! defined( 'CLEF_WP_SESSION_COOKIE' ) )
+                define( 'CLEF_WP_SESSION_COOKIE', self::$cookie_name );
 
             if ( ! class_exists( 'Recursive_ArrayAccess' ) )
                 require_once CLEF_PATH . 'includes/lib/wp-session/class-recursive-arrayaccess.php';
 
-            if ( ! class_exists( 'WP_Session' ) ) {
+            if ( ! class_exists( '\Clef\WP_Session' ) ) {
                 require_once CLEF_PATH . 'includes/lib/wp-session/class-wp-session.php';
                 require_once CLEF_PATH . 'includes/lib/wp-session/wp-session.php';
             }
 
-            add_filter( 'wp_session_expiration', array( $this, 'set_expiration_time' ), 99999 );
+            add_filter( 'clef_wp_session_expiration', array( $this, 'set_expiration_time' ), 99999 );
         }
 
         $this->init($cookie_name);
@@ -85,7 +85,7 @@ class ClefSession {
         if( $this->use_php_sessions )
             $this->session = isset( $_SESSION['clef'] ) && is_array( $_SESSION['clef'] ) ? $_SESSION['clef'] : array();
         else
-            $this->session = WP_Session::get_instance($cookie_name);
+            $this->session = \Clef\WP_Session::get_instance($cookie_name);
 
         return $this->session;
     }
@@ -155,12 +155,12 @@ class ClefSession {
         if ( ! class_exists( 'Recursive_ArrayAccess' ) )
             require_once CLEF_PATH . 'includes/lib/wp-session/class-recursive-arrayaccess.php';
 
-        if ( ! class_exists( 'WP_Session' ) ) {
+        if ( ! class_exists( '\Clef\WP_Session' ) ) {
             require_once CLEF_PATH . 'includes/lib/wp-session/class-wp-session.php';
             require_once CLEF_PATH . 'includes/lib/wp-session/wp-session.php';
         }
 
-        $old_session = new WP_Session($old_cookie_name);
+        $old_session = new \Clef\WP_Session($old_cookie_name);
         $new_session = ClefSession::start();
 
         foreach ($old_session as $key => $value) {

--- a/includes/lib/wp-session/class-wp-session.php
+++ b/includes/lib/wp-session/class-wp-session.php
@@ -10,13 +10,15 @@
  * @since   3.7.0
  */
 
+namespace Clef;
+
 /**
  * WordPress Session class for managing user session data.
  *
  * @package WordPress
  * @since   3.7.0
  */
-final class WP_Session extends Recursive_ArrayAccess implements Iterator, Countable {
+final class WP_Session extends \Recursive_ArrayAccess implements \Iterator, \Countable {
     /**
      * ID of the current session.
      *
@@ -72,7 +74,7 @@ final class WP_Session extends Recursive_ArrayAccess implements Iterator, Counta
         if ($cookie_name) {
             $this->cookie_name = $cookie_name;
         } else {
-            $this->cookie_name = WP_SESSION_COOKIE;
+            $this->cookie_name = CLEF_WP_SESSION_COOKIE;
         }
 
         if ( isset( $_COOKIE[$this->cookie_name] ) ) {
@@ -119,8 +121,8 @@ final class WP_Session extends Recursive_ArrayAccess implements Iterator, Counta
      * @uses apply_filters Calls `wp_session_expiration` to get the standard expiration time for sessions.
      */
     protected function set_expiration() {
-        $this->exp_variant = time() + (int) apply_filters( 'wp_session_expiration_variant', 24 * 60 );
-        $this->expires = time() + (int) apply_filters( 'wp_session_expiration', 30 * 60 );
+        $this->exp_variant = time() + (int) apply_filters( 'clef_wp_session_expiration_variant', 24 * 60 );
+        $this->expires = time() + (int) apply_filters( 'clef_wp_session_expiration', 30 * 60 );
     }
 
     /**
@@ -137,7 +139,7 @@ final class WP_Session extends Recursive_ArrayAccess implements Iterator, Counta
      */
     protected function generate_id() {
         require_once( ABSPATH . 'wp-includes/class-phpass.php');
-        $hasher = new PasswordHash( 8, false );
+        $hasher = new \PasswordHash( 8, false );
 
         return md5( $hasher->get_random_bytes( 32 ) );
     }

--- a/includes/lib/wp-session/wp-session.php
+++ b/includes/lib/wp-session/wp-session.php
@@ -10,13 +10,14 @@
  * @since   3.7.0
  */
 
+namespace Clef;
 /**
  * Return the current cache expire setting.
  *
  * @return int
  */
 function wp_session_cache_expire() {
-    $wp_session = WP_Session::get_instance();
+    $wp_session = \Clef\WP_Session::get_instance();
 
     return $wp_session->cache_expiration();
 }
@@ -34,7 +35,7 @@ function wp_session_commit() {
  * @param string $data
  */
 function wp_session_decode( $data ) {
-    $wp_session = WP_Session::get_instance();
+    $wp_session = \Clef\WP_Session::get_instance();
 
     return $wp_session->json_in( $data );
 }
@@ -45,7 +46,7 @@ function wp_session_decode( $data ) {
  * @return string
  */
 function wp_session_encode() {
-    $wp_session = WP_Session::get_instance();
+    $wp_session = \Clef\WP_Session::get_instance();
 
     return $wp_session->json_out();
 }
@@ -58,7 +59,7 @@ function wp_session_encode() {
  * @return bool
  */
 function wp_session_regenerate_id( $delete_old_session = false ) {
-    $wp_session = WP_Session::get_instance();
+    $wp_session = \Clef\WP_Session::get_instance();
 
     $wp_session->regenerate_id( $delete_old_session );
 
@@ -73,12 +74,12 @@ function wp_session_regenerate_id( $delete_old_session = false ) {
  * @return bool
  */
 function wp_session_start() {
-    $wp_session = WP_Session::get_instance();
-    do_action( 'wp_session_start' );
+    $wp_session = \Clef\WP_Session::get_instance();
+    do_action( 'clef_wp_session_start' );
 
     return $wp_session->session_started();
 }
-add_action( 'plugins_loaded', 'wp_session_start' );
+add_action( 'plugins_loaded', '\Clef\wp_session_start' );
 
 /**
  * Return the current session status.
@@ -86,7 +87,7 @@ add_action( 'plugins_loaded', 'wp_session_start' );
  * @return int
  */
 function wp_session_status() {
-    $wp_session = WP_Session::get_instance();
+    $wp_session = \Clef\WP_Session::get_instance();
 
     if ( $wp_session->session_started() ) {
         return PHP_SESSION_ACTIVE;
@@ -99,7 +100,7 @@ function wp_session_status() {
  * Unset all session variables.
  */
 function wp_session_unset() {
-    $wp_session = WP_Session::get_instance();
+    $wp_session = \Clef\WP_Session::get_instance();
 
     $wp_session->reset();
 }
@@ -108,12 +109,12 @@ function wp_session_unset() {
  * Write session data and end session
  */
 function wp_session_write_close() {
-    $wp_session = WP_Session::get_instance();
+    $wp_session = \Clef\WP_Session::get_instance();
 
     $wp_session->write_data();
-    do_action( 'wp_session_commit' );
+    do_action( 'clef_wp_session_commit' );
 }
-add_action( 'shutdown', 'wp_session_write_close' );
+add_action( 'shutdown', '\Clef\wp_session_write_close' );
 
 /**
  * Clean up expired sessions by removing data and their expiration entries from
@@ -154,16 +155,16 @@ function wp_session_cleanup() {
     }
 
     // Allow other plugins to hook in to the garbage collection process.
-    do_action( 'wp_session_cleanup' );
+    do_action( 'clef_wp_session_cleanup' );
 }
-add_action( 'wp_session_garbage_collection', 'wp_session_cleanup' );
+add_action( 'wp_session_garbage_collection', '\Clef\wp_session_cleanup' );
 
 /**
  * Register the garbage collector as a twice daily event.
  */
 function wp_session_register_garbage_collection() {
     if ( ! wp_next_scheduled( 'wp_session_garbage_collection' ) ) {
-        wp_schedule_event( time(), 'hourly', 'wp_session_garbage_collection' );
+        wp_schedule_event( time(), 'hourly', '\Clef\wp_session_garbage_collection' );
     }
 }
-add_action( 'wp', 'wp_session_register_garbage_collection' );
+add_action( 'wp', '\Clef\wp_session_register_garbage_collection' );


### PR DESCRIPTION
This commit namespaces WP_Session to \Clef\WP_Session to avoid conflicts with
other plugins that load the code. This fixes the issue that caused 2.5.0 to be
pulled.