### PR TITLE
Add casting to third setcookie() param

### DIFF
--- a/includes/lib/wp-session/class-wp-session.php
+++ b/includes/lib/wp-session/class-wp-session.php
@@ -127,7 +127,7 @@ final class ClefWP_Session extends Recursive_ArrayAccess implements Iterator, Co
      * Set the session cookie
      */
     protected function set_cookie() {
-        setcookie( $this->cookie_name, $this->session_id . '||' . $this->expires . '||' . $this->exp_variant , $this->expires, COOKIEPATH, COOKIE_DOMAIN );
+        setcookie( $this->cookie_name, $this->session_id . '||' . $this->expires . '||' . $this->exp_variant , (int) $this->expires, COOKIEPATH, COOKIE_DOMAIN );
     }
 
     /**


### PR DESCRIPTION
User reported issue [here](https://wordpress.org/support/topic/setcookie-parameter-error-on-php-7?replies=1#post-8417024).

Verified in local testing. To repro:

1. Install wpclef on a server running PHP7
1. Upon activation, Dashboard returns the following error:

```Warning: setcookie() expects parameter 3 to be integer, string given in /Applications/AMPPS/www/wordpress/wp-content/plugins/wpclef/includes/lib/wp-session/class-wp-session.php on line 130 ```