### PR TITLE
Remove empty div

### DIFF
--- a/templates/admin/settings.tpl.php
+++ b/templates/admin/settings.tpl.php
@@ -1,6 +1,4 @@
 <div id="clef-settings-container">
-    <div class="message"><p></p></div>
-
     <?php if ($options['isMultisite']) { ?>
     <div id='clef-multisite-options'>
         <?php include CLEF_TEMPLATE_PATH . 'admin/multisite.tpl.php'; ?>


### PR DESCRIPTION
This was displaying as an empty `div class=message` upon completing the setup wizard on some hosts (e.g., WP Engine) but not others (e.g., GoDaddy).

Appears to be unused. . . .