### PR TITLE
Accommodate WP Engine servers

### DIFF
--- a/clef-require.php
+++ b/clef-require.php
@@ -36,8 +36,8 @@ class Clef {
         
         // Accommodate WP Engine's throttle on the Heartbeat API
         if ( class_exists('WPE_Heartbeat_Throttle') ) {
-		    if (!defined('WPE_HEARTBEAT_INTERVAL')) define('WPE_HEARTBEAT_INTERVAL', 5);
-	    }
+            if (!defined('WPE_HEARTBEAT_INTERVAL')) define('WPE_HEARTBEAT_INTERVAL', 5);
+        }
     }
 
     public static function start() {

--- a/clef-require.php
+++ b/clef-require.php
@@ -33,6 +33,11 @@ class Clef {
         if (!defined('CLEF_BASE')) define( 'CLEF_BASE', 'https://clef.io');
         if (!defined('CLEF_JS_URL')) define( 'CLEF_JS_URL', CLEF_BASE . '/v3/clef.js');
         if (!defined('CLEF_API_BASE')) define( 'CLEF_API_BASE', CLEF_BASE . '/api/v1/');
+        
+        // Accommodate WP Engine's throttle on the Heartbeat API
+        if ( class_exists('WPE_Heartbeat_Throttle') ) {
+		    if (!defined('WPE_HEARTBEAT_INTERVAL')) define('WPE_HEARTBEAT_INTERVAL', 5);
+	    }
     }
 
     public static function start() {

--- a/includes/class.clef-admin.php
+++ b/includes/class.clef-admin.php
@@ -208,7 +208,7 @@ class ClefAdmin {
             'setup' => array(
                 'siteName' => get_option('blogname'),
                 'siteDomain' => get_option('siteurl'),
-                'logoutHook' => wp_login_url(),
+                'logoutHook' => ClefUtils::get_logout_hook_url(),
                 'source' => 'wordpress',
                 'affiliates' => apply_filters('clef_add_affiliate', array())
             ),

--- a/includes/class.clef-logout.php
+++ b/includes/class.clef-logout.php
@@ -119,7 +119,7 @@ class ClefLogout {
      * Remove WP Engine's reduced scope for the Heartbeat API (i.e., editing-only pages) so that the WP logout modal will appear
      * when the Clef logout hook is received.
      */
-    private function increase_heartbeat_scope_for_wpe( $heartbeat_allowed_pages ) {
+    public function increase_heartbeat_scope_for_wpe( $heartbeat_allowed_pages ) {
         $heartbeat_allowed_pages[] = 'admin.php';
         $heartbeat_allowed_pages[] = 'customize.php';
         $heartbeat_allowed_pages[] = 'edit-comments.php';

--- a/includes/class.clef-logout.php
+++ b/includes/class.clef-logout.php
@@ -17,7 +17,10 @@ class ClefLogout {
             add_filter('init', array($this, "logged_out_check_with_redirect"));
         }
         
-        // Add this filter to expand the scope of the Heartbeat API only if we're running on a WP Engine server
+        /**
+        * Accommodate WP Engine's restriction on the scope of the Heartbeat API (i.e., restricted to post/page editing pages only)
+        * by expanding the scope to all pages in WP Dashboard; this scope is required for Clef to display the WP logout modal upon Clef-enabled logouts.
+        */
         if ( class_exists('WPE_Heartbeat_Throttle') ) {
             add_filter( 'wpe_heartbeat_allowed_pages', array( $this, 'increase_heartbeat_scope_for_wpe') );
         }
@@ -134,6 +137,8 @@ class ClefLogout {
         $heartbeat_allowed_pages[] = 'options-permalink.php';
         $heartbeat_allowed_pages[] = 'options-reading.php';
         $heartbeat_allowed_pages[] = 'options-writing.php';
+        $heartbeat_allowed_pages[] = 'plugin-editor.php';
+        $heartbeat_allowed_pages[] = 'plugin-install.php';
         $heartbeat_allowed_pages[] = 'plugins.php';
         $heartbeat_allowed_pages[] = 'profile.php';
         $heartbeat_allowed_pages[] = 'themes.php';

--- a/includes/class.clef-logout.php
+++ b/includes/class.clef-logout.php
@@ -16,6 +16,11 @@ class ClefLogout {
         if (!defined('DOING_AJAX') || !DOING_AJAX) {
             add_filter('init', array($this, "logged_out_check_with_redirect"));
         }
+        
+        // Add this filter to expand the scope of the Heartbeat API only if we're running on a WP Engine server
+        if ( class_exists('WPE_Heartbeat_Throttle') ) {
+            add_filter( 'wpe_heartbeat_allowed_pages', array( $this, 'increase_heartbeat_scope_for_wpe') );
+        }
     }
 
     /**
@@ -107,6 +112,39 @@ class ClefLogout {
             self::$instance = new self($settings);
         }
         return self::$instance;
+    }
+    
+    /***
+     * Ported from Jeremy Pry (http://jeremypry.com/); Original: https://gist.github.com/JPry/b1f6c55a5d5337557f97
+     * Remove WP Engine's reduced scope for the Heartbeat API (i.e., editing-only pages) so that the WP logout modal will appear
+     * when the Clef logout hook is received.
+     */
+    private function increase_heartbeat_scope_for_wpe( $heartbeat_allowed_pages ) {
+        $heartbeat_allowed_pages[] = 'admin.php';
+        $heartbeat_allowed_pages[] = 'customize.php';
+        $heartbeat_allowed_pages[] = 'edit-comments.php';
+        $heartbeat_allowed_pages[] = 'export.php';
+        $heartbeat_allowed_pages[] = 'import.php';
+        $heartbeat_allowed_pages[] = 'index.php.php';
+        $heartbeat_allowed_pages[] = 'media-new.php';
+        $heartbeat_allowed_pages[] = 'nav-menus.php';
+        $heartbeat_allowed_pages[] = 'options-discussion.php';
+        $heartbeat_allowed_pages[] = 'options-general.php';
+        $heartbeat_allowed_pages[] = 'options-media.php';
+        $heartbeat_allowed_pages[] = 'options-permalink.php';
+        $heartbeat_allowed_pages[] = 'options-reading.php';
+        $heartbeat_allowed_pages[] = 'options-writing.php';
+        $heartbeat_allowed_pages[] = 'plugins.php';
+        $heartbeat_allowed_pages[] = 'profile.php';
+        $heartbeat_allowed_pages[] = 'themes.php';
+        $heartbeat_allowed_pages[] = 'tools.php';
+        $heartbeat_allowed_pages[] = 'update-core.php';
+        $heartbeat_allowed_pages[] = 'upload.php';
+        $heartbeat_allowed_pages[] = 'users.php';
+        $heartbeat_allowed_pages[] = 'user-new.php';
+        $heartbeat_allowed_pages[] = 'widgets.php';
+        
+        return $heartbeat_allowed_pages;
     }
 }
 ?>

--- a/includes/class.clef-utils.php
+++ b/includes/class.clef-utils.php
@@ -295,5 +295,16 @@ class ClefUtils {
 
         return $sent;
     }
+    
+    public static function get_logout_hook_url() {
+        $logout_hook_url = wp_login_url();
+        
+        // Accommodate WP Engine's firewall rules, which require a wpe-login param on POST requests to the login script URL
+        if ( function_exists( 'wpe_site' ) ) {
+            $logout_hook_url = add_query_arg('wpe-login', 'clef', $logout_hook_url);
+        }
+
+        return $logout_hook_url;
+    }
 }
 ?>


### PR DESCRIPTION
This PR implements automations for the current manual workarounds that are required after installing the Clef 2FA plugin on a WP Engine server; in other words, these changes make the plugin plug-n-play for WPE users:

1. The `wpe-login=clef` param is added to the Logout Hook URL during plugin installation

1. WPE's 60-sec. Heartbeat API interval throttle is changed to 5 sec.

1. WPE's restriction on the scope of the Heartbeat API (i.e., it applies only to editing pages) is set back to its default scope (i.e., all pages) via the `wpe_heartbeat_allowed_pages` filter.