### PR TITLE
Fix WP cron garbage collection scheduler

### DIFF
--- a/includes/lib/wp-session/wp-session.php
+++ b/includes/lib/wp-session/wp-session.php
@@ -159,10 +159,10 @@ function clef_wp_session_cleanup() {
 add_action( 'wp_session_garbage_collection', 'clef_wp_session_cleanup' );
 
 /**
- * Register the garbage collector as a twice daily event.
+ * Register the garbage collector.
  */
 function clef_wp_session_register_garbage_collection() {
-    if ( ! wp_next_scheduled( 'wp_session_garbage_collection' ) ) {
+    if ( ! wp_next_scheduled( 'clef_wp_session_garbage_collection' ) ) {
         wp_schedule_event( time(), 'hourly', 'clef_wp_session_garbage_collection' );
     }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -150,6 +150,11 @@ Clef employs a distributed security architecture, which means Clef stores no use
 
 == Changelog ==
 
+= 2.5.5 =
+Released 20 June 2016
+
+* Fix: WP cron scheduler adding excess session garbage collection events ([253](https://github.com/clef/clef-wordpress/pull/253))
+
 = 2.5.4 =
 Released 16 June 2016
 


### PR DESCRIPTION
Resolves issue reported here: https://wordpress.org/support/topic/clef_wp_session_garbage_collection-mysql-crash?replies=7

Fix tested and verified locally and on user's site (see above report).

Recommended release date for Monday, June 20.