### PR TITLE
Enhance Clef state and session cookie flags

### DIFF
--- a/includes/class.clef-utils.php
+++ b/includes/class.clef-utils.php
@@ -250,7 +250,7 @@ class ClefUtils {
         if (!$override && isset($_COOKIE[self::$cookie_name]) && $_COOKIE[self::$cookie_name]) return;
 
         $state = wp_generate_password(24, false);
-        @setcookie(self::$cookie_name, $state, (time() + 60 * 60 * 24), '/', '', is_ssl(), true);
+        @setcookie(self::$cookie_name, $state, (time() + 60 * 60 * 24), '/', '', ClefUtils::is_tls(), true);
         $_COOKIE[self::$cookie_name] = $state;
 
         return $state;
@@ -305,6 +305,16 @@ class ClefUtils {
         }
 
         return $logout_hook_url;
+    }
+    
+    public static function is_tls() {
+        if ( is_ssl() ) {
+            return true;
+        } elseif ( isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https' )  {
+            return true;
+        } else {
+            return false;
+        }
     }
 }
 ?>

--- a/includes/class.clef-utils.php
+++ b/includes/class.clef-utils.php
@@ -308,13 +308,7 @@ class ClefUtils {
     }
     
     public static function is_tls() {
-        if ( is_ssl() ) {
-            return true;
-        } elseif ( isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https' )  {
-            return true;
-        } else {
-            return false;
-        }
+        return is_ssl() || (isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https');
     }
 }
 ?>

--- a/includes/lib/wp-session/class-wp-session.php
+++ b/includes/lib/wp-session/class-wp-session.php
@@ -127,7 +127,7 @@ final class ClefWP_Session extends Recursive_ArrayAccess implements Iterator, Co
      * Set the session cookie
      */
     protected function set_cookie() {
-        setcookie( $this->cookie_name, $this->session_id . '||' . $this->expires . '||' . $this->exp_variant , (int) $this->expires, COOKIEPATH, COOKIE_DOMAIN, is_ssl(), true );
+        setcookie( $this->cookie_name, $this->session_id . '||' . $this->expires . '||' . $this->exp_variant , (int) $this->expires, COOKIEPATH, COOKIE_DOMAIN, ClefUtils::is_tls(), true );
     }
 
     /**

--- a/includes/lib/wp-session/class-wp-session.php
+++ b/includes/lib/wp-session/class-wp-session.php
@@ -127,7 +127,7 @@ final class ClefWP_Session extends Recursive_ArrayAccess implements Iterator, Co
      * Set the session cookie
      */
     protected function set_cookie() {
-        setcookie( $this->cookie_name, $this->session_id . '||' . $this->expires . '||' . $this->exp_variant , (int) $this->expires, COOKIEPATH, COOKIE_DOMAIN );
+        setcookie( $this->cookie_name, $this->session_id . '||' . $this->expires . '||' . $this->exp_variant , (int) $this->expires, COOKIEPATH, COOKIE_DOMAIN, is_ssl(), true );
     }
 
     /**


### PR DESCRIPTION
1. Add `httponly` flag to `wordpress_clef_session` cookie
1. Conditionally add `secure` flag to `wordpress_clef_session` and `wordpress_clef_state` cookies
1. In the condition for the `secure` flag, add support for reverse-proxy-based TLS a la the recommendation in [codex](https://developer.wordpress.org/reference/functions/is_ssl/).